### PR TITLE
Adding throam.com to time-bound domains

### DIFF
--- a/data/time_bound_domains.txt
+++ b/data/time_bound_domains.txt
@@ -47,6 +47,7 @@ tempemail.net
 tempinbox.com
 temporaryinbox.com
 temporarily.de
+throam.com
 trashdevil.com
 trashdevil.de
 trashmail.net


### PR DESCRIPTION
These are addresses generated from http://www.throwawaymail.com/
such as the one that was used to spam mantisbt.org in April 2015.

If you accept this PR, please update the library in mantisbt repository after merging.