### PR TITLE
Adding mailsocket.us.to to trash domains

### DIFF
--- a/data/trash_domains.txt
+++ b/data/trash_domains.txt
@@ -67,6 +67,7 @@ mailmetrash.com
 mailnesia.com
 mailquack.com
 mailslapping.com
+mailsocket.us.to
 meltmail.com
 mmmmail.com
 mt2009.com


### PR DESCRIPTION
I added this to trash domains. If it belongs in a different data file, contact me.