### PR TITLE
Add DisposableEmailChecker::is_subaddressed_email() method

### DIFF
--- a/php/disposable.php
+++ b/php/disposable.php
@@ -92,6 +92,23 @@ class DisposableEmailChecker
 	}
 
 	/**
+	 * Determines whether a given email address is subaddressed or not.
+	 * Subaddressed email addresses, also known as plus addresses or tagged
+	 * addresses, have the form username+tag@domain.tld.
+	 *
+	 * @param string $address  An email address to test.
+	 * @returns true: subaddressed email, false: otherwise.
+	 *
+	 * @see https://en.wikipedia.org/wiki/Email_address#Sub-addressing
+	 */
+	public static function is_subaddressed_email($address) {
+		// A subaddressed email address must contain a username and a plus sign.
+		// Match any string that begins with one or more characters other than
+		// an at sign (@), followed by a plus sign (+).
+		return (preg_match('/^[^@]+\+/', $address) == 1);
+	}
+
+	/**
 	 * Determines if the email address is time bound, these are the disposable
 	 * addresses that auto expire after a pre-configured time.  For example,
 	 * 10 minutes, 1 hour, 2 hours, 1 day, 1 month, etc.  These address can

--- a/php/tests/disposable_email_checker_tests.php
+++ b/php/tests/disposable_email_checker_tests.php
@@ -49,6 +49,30 @@ class DisposableEmailCheckerTests extends PHPUnit_Framework_TestCase
 		$this->assertFalse( DisposableEmailChecker::is_shredder_email( 'mantishub.com' ) );
 	}
 
+	/**
+	 * @dataProvider providerIsSubaddressedEmail
+	 */
+	public function testSubaddressedEmail($expected, $address) {
+		$this->assertEquals( $expected, DisposableEmailChecker::is_subaddressed_email( $address ) );
+	}
+
+	public function providerIsSubaddressedEmail() {
+		// Subaddressed
+		$tests[] = array( TRUE, 'username+tag@example.com' );
+		$tests[] = array( TRUE, 'username+tag+@example.com' );
+		$tests[] = array( TRUE, 'username++tag@example.com' );
+		$tests[] = array( TRUE, 'username+@example.com' );
+		$tests[] = array( TRUE, 'username++@example.com' );
+
+		// Non-subaddressed
+		$tests[] = array( FALSE, 'username@example.com' );
+		$tests[] = array( FALSE, '+tag@example.com' );
+		$tests[] = array( FALSE, 'username@sub+domain.example.com' );
+		$tests[] = array( FALSE, '' );
+
+		return $tests;
+	}
+
 	public function testTimeBoundDomain() {
 		$this->assertTrue( DisposableEmailChecker::is_time_bound_email( 'someone@getonemail.com' ) );
 		$this->assertTrue( DisposableEmailChecker::is_time_bound_email( 'getonemail.com' ) );


### PR DESCRIPTION
[Sub-addressed emails](https://en.wikipedia.org/wiki/Email_address#Sub-addressing), sometimes called "plus addresses" or "tagged addresses", may be considered another form of disposable email. They allow a user to create variations on their email address that really all go to the same account, allowing them to bypass requirements for unique email addresses or to filter or block incoming mail based on tag. This pull request adds a method for detecting sub-addressed emails. I didn't add a call to the method to `DisposableEmailChecker::is_disposable_email()` because the test is less cut-and-dried than the others. It's a matter of email server configuration what character separates the username from the tag. And while the plus sign (`+`) is most common, there are notable exceptions. The test could be sophisticated to account for known exceptions kept in text files in the `data` directory. I thought this was a good first step to get your thoughts on it, @vboctor. I included unit tests and tried to match your coding conventions.