### PR TITLE
Adding additional disposable domains seen in the wild

### DIFF
--- a/data/time_bound_domains.txt
+++ b/data/time_bound_domains.txt
@@ -47,6 +47,7 @@ oopi.org
 pookmail.com
 reallymymail.com
 shortmail.net
+spam4.me
 spambox.us
 spamfree24.com
 spamfree24.org

--- a/data/time_bound_domains.txt
+++ b/data/time_bound_domains.txt
@@ -13,8 +13,14 @@ dontreg.com
 dotmsg.com
 emailto.de
 getonemail.com
+grr.la
+guerrillamail.biz
 guerrillamail.com
+guerrillamail.de
+guerrillamail.info
 guerrillamail.net
+guerrillamail.org
+guerrillamailblock.com
 haltospam.com
 jetable.com
 jetable.net

--- a/data/trash_domains.txt
+++ b/data/trash_domains.txt
@@ -146,4 +146,4 @@ wilemail.com
 willselfdestruct.com
 xagloo.com
 yopmail.com
-
+yopmail.net

--- a/data/trash_domains.txt
+++ b/data/trash_domains.txt
@@ -17,15 +17,19 @@ amiri.net
 amiriindustries.com
 anonymail.dk
 anonymbox.com
+armyspay.com
 bspamfree.org
 bugmenot.com
 buyusedlibrarybooks.org
+cuvox.de
+dayrep.com
 deadaddress.com
 discardmail.com
 disposeamail.com
 dispostable.com
 dodgeit.com
 dontsendmespam.de
+einrot.com
 emaildienst.de
 emailmiser.com
 emailthe.net
@@ -44,6 +48,7 @@ fastsubaru.com
 fastsuzuki.com
 fasttoyota.com
 fastyamaha.com
+fleckens.hu
 getonemail.com
 gowikibooks.com
 gowikicampus.com
@@ -54,10 +59,12 @@ gowikimusic.com
 gowikinetwork.com
 gowikitravel.com
 gowikitv.com
+gustr.com
 haltospam.com
 ichimail.com
 incognitomail.org
 ipoo.org
+jourrapide.com
 killmail.net
 klassmaster.com
 kurzepost.de
@@ -98,6 +105,7 @@ proxymail.eu
 rcpt.at
 recyclemail.dk
 rejectmail.com
+rhyta.com
 rklips.com
 sharklasers.com
 shortmail.net
@@ -112,6 +120,8 @@ spamfree24.com
 spamfree24.net
 spamfree24.org
 spaml.com
+supperrito.com
+teleworm.us
 tempemail.net
 tempinbox.com
 tempomail.fr


### PR DESCRIPTION
The domains addressed in this PR were submitted as registration email addresses on a site with which I work.  The commit messages for each reference the source, for validation that they are disposable.

Where variants of the domain already existed (e.g., yopmail, guerrillamail) I added the new ones to the files where the existing ones were listed though I'm not sure those are really accurate.  For example, guerrillamail is listed as time bound when to my read it's really a trash domain.