### PR TITLE
Moving guerrillamail and associated domains from time bound to trash

### DIFF
--- a/data/time_bound_domains.txt
+++ b/data/time_bound_domains.txt
@@ -13,14 +13,6 @@ dontreg.com
 dotmsg.com
 emailto.de
 getonemail.com
-grr.la
-guerrillamail.biz
-guerrillamail.com
-guerrillamail.de
-guerrillamail.info
-guerrillamail.net
-guerrillamail.org
-guerrillamailblock.com
 haltospam.com
 jetable.com
 jetable.net

--- a/data/trash_domains.txt
+++ b/data/trash_domains.txt
@@ -59,6 +59,14 @@ gowikimusic.com
 gowikinetwork.com
 gowikitravel.com
 gowikitv.com
+grr.la
+guerrillamail.biz
+guerrillamail.com
+guerrillamail.de
+guerrillamail.info
+guerrillamail.net
+guerrillamail.org
+guerrillamailblock.com
 gustr.com
 haltospam.com
 ichimail.com


### PR DESCRIPTION
As described on the [guerrillamail.com](https://www.guerrillamail.com/) site, guerrillamail and associated domains are more trash than time bound.

> Avoid spam and stay safe - use a disposable email address! 
