### PR TITLE
Add netmail8.com

### DIFF
--- a/data/domains.txt
+++ b/data/domains.txt
@@ -1175,6 +1175,7 @@ neomailbox.com
 nepwk.com
 nervmich.net
 nervtmich.net
+netmail8.com
 netmails.com
 netmails.net
 netterchef.de


### PR DESCRIPTION
Recently someone with netmail8.com domain registered to one of my services. According to the https://check-mail.org/ that domain is a disposable email ([here](https://check-mail.org/domain/netmail8.com/)).